### PR TITLE
feat(board): finish bubbles and lipgloss board architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ The CLI is the only product surface today. It writes append-only events, rebuild
 - replay, migration, verification, and backup database operations
 - human password-based mutation auth and explicit LLM provenance for automation
 
+## Interactive board architecture
+
+The interactive `memori board` path is intentionally CLI-native and terminal-first, but it follows a clear UI architecture:
+
+- Bubble Tea owns the board runtime: program lifecycle, messages, refresh scheduling, resize handling, and async snapshot/audit loading.
+- Bubbles owns generic interactive surfaces inside the board: search input, inspector viewport behavior, help metadata, and loading spinner behavior.
+- Lip Gloss is the sole board styling and layout layer for headers, tabs, panels, rows, overlays, help surfaces, footer text, toast states, and framed layouts.
+- Board-specific code owns domain state and content assembly: lane selection, hierarchy navigation, detail vs continuity mode, history toggle, search result ranking, and continuity guidance text.
+
+When adding new board UI behavior, prefer extending those layers instead of introducing bespoke terminal widgets or raw ANSI assembly. New interactive surfaces should default to Bubble Tea plus Bubbles components, and new visual treatment should be expressed through Lip Gloss styles and layout primitives.
+
 ## Current boundaries
 
 memori is already useful for local workflow design and disciplined execution, but it is still intentionally narrow:

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,9 @@ require (
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/charmbracelet/bubbles v0.21.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/charmbracelet/bubbles v0.21.0 h1:9TdC97SdRVg/1aaXNVWfFH3nnLAwOXr8Fn6u6mfQdFs=
+github.com/charmbracelet/bubbles v0.21.0/go.mod h1:HF+v6QUR4HkEpz62dx7ym2xc71/KBHg+zKwJtMw+qtg=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=

--- a/internal/cli/board_tui.go
+++ b/internal/cli/board_tui.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/willbastian/memori/internal/store"
 )
@@ -17,7 +18,6 @@ type boardTUIProgram interface {
 }
 
 type boardRefreshTickMsg struct{}
-type boardSpinnerTickMsg struct{}
 type boardToastExpiredMsg struct {
 	id int
 }
@@ -119,7 +119,7 @@ func (model boardTeaModel) Init() tea.Cmd {
 		requestID := model.state.activeAuditRequestID
 		cmds = append(cmds,
 			boardLoadAuditCmd(model.ctx, model.store, model.agent, model.state.selectedIssue, requestID),
-			boardScheduleSpinner(),
+			model.state.spinner.Tick,
 		)
 	}
 	return tea.Batch(cmds...)
@@ -133,12 +133,22 @@ func (model boardTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		model.state = boardNormalizeModel(model.state)
 		return model, nil
 	case tea.KeyMsg:
-		input, ok := boardKeyInputFromKeyMsg(msg)
-		if !ok {
-			return model, nil
-		}
 		previous := model.state
-		nextState, quit := boardHandleInput(model.state, input)
+		var (
+			nextState boardTUIModel
+			quit      bool
+			input     boardKeyInput
+			ok        bool
+		)
+		if model.state.searchOpen {
+			nextState, quit = boardHandleSearchInput(model.state, msg)
+		} else {
+			input, ok = boardKeyInputFromKeyMsg(msg)
+			if !ok {
+				return model, nil
+			}
+			nextState, quit = boardHandleInput(model.state, input)
+		}
 		model.state = nextState
 		if quit {
 			return model, tea.Quit
@@ -150,7 +160,7 @@ func (model boardTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, boardLoadAuditCmd(model.ctx, model.store, model.agent, model.state.selectedIssue, requestID))
 		}
 		if !boardAnyLoading(previous) && boardAnyLoading(model.state) {
-			cmds = append(cmds, boardScheduleSpinner())
+			cmds = append(cmds, model.state.spinner.Tick)
 		}
 		if model.state.toast.id != 0 && model.state.toast.id != previous.toast.id {
 			cmds = append(cmds, boardExpireToastCmd(model.state.toast.id))
@@ -165,7 +175,7 @@ func (model boardTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			boardScheduleRefresh(model.interval),
 		}
 		if !wasLoading {
-			cmds = append(cmds, boardScheduleSpinner())
+			cmds = append(cmds, model.state.spinner.Tick)
 		}
 		return model, tea.Batch(cmds...)
 	case boardSnapshotLoadedMsg:
@@ -196,7 +206,7 @@ func (model boardTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, boardLoadAuditCmd(model.ctx, model.store, model.agent, model.state.selectedIssue, requestID))
 		}
 		if !wasLoading && boardAnyLoading(model.state) {
-			cmds = append(cmds, boardScheduleSpinner())
+			cmds = append(cmds, model.state.spinner.Tick)
 		}
 		return model, tea.Batch(cmds...)
 	case boardAuditLoadedMsg:
@@ -225,12 +235,13 @@ func (model boardTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			model.state.auditLoad = boardSucceedAsyncLoad(model.state.auditLoad, boardTUINow())
 		}
 		return model, nil
-	case boardSpinnerTickMsg:
+	case spinner.TickMsg:
 		if !boardAnyLoading(model.state) {
 			return model, nil
 		}
-		model.state.spinnerFrame++
-		return model, boardScheduleSpinner()
+		var cmd tea.Cmd
+		model.state.spinner, cmd = model.state.spinner.Update(msg)
+		return model, cmd
 	case boardToastExpiredMsg:
 		model.state = boardClearToast(model.state, msg.id)
 		return model, nil
@@ -264,12 +275,6 @@ func boardLoadAuditCmd(ctx context.Context, s *store.Store, agent, issueID strin
 		audit, err := boardTUIBuildAudit(ctx, s, issueID, agent)
 		return boardAuditLoadedMsg{requestID: requestID, issueID: issueID, audit: audit, err: err}
 	}
-}
-
-func boardScheduleSpinner() tea.Cmd {
-	return tea.Tick(120*time.Millisecond, func(time.Time) tea.Msg {
-		return boardSpinnerTickMsg{}
-	})
 }
 
 func boardExpireToastCmd(id int) tea.Cmd {

--- a/internal/cli/board_tui_components.go
+++ b/internal/cli/board_tui_components.go
@@ -8,7 +8,6 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
-	"github.com/charmbracelet/lipgloss"
 )
 
 func newBoardSearchInput() textinput.Model {
@@ -118,12 +117,4 @@ func boardHelpView(model boardTUIModel, theme boardTheme, width int, full bool) 
 func boardSearchInputView(model boardTUIModel, theme boardTheme, width int) string {
 	input := boardStyledSearchInput(model.searchInput, theme, width)
 	return input.View()
-}
-
-func boardSpinnerView(model boardTUIModel, theme boardTheme) string {
-	return boardStyledSpinner(model.spinner, theme).View()
-}
-
-func boardLipGlossWidth(value string) int {
-	return lipgloss.Width(value)
 }

--- a/internal/cli/board_tui_components.go
+++ b/internal/cli/board_tui_components.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func newBoardSearchInput() textinput.Model {
+	input := textinput.New()
+	input.Prompt = "/"
+	input.Placeholder = "issue id"
+	input.CharLimit = 64
+	return input
+}
+
+func newBoardHelp() help.Model {
+	return help.New()
+}
+
+func newBoardSpinner() spinner.Model {
+	return spinner.New(spinner.WithSpinner(spinner.Line))
+}
+
+func newBoardViewport() viewport.Model {
+	return viewport.New(1, 1)
+}
+
+func boardStyledSearchInput(input textinput.Model, theme boardTheme, width int) textinput.Model {
+	input.Width = maxInt(width-2, 1)
+	input.PromptStyle = theme.lineStyle(theme.detailFG, "", true, false)
+	input.TextStyle = theme.lineStyle(theme.detailFG, "", false, false)
+	input.PlaceholderStyle = theme.lineStyle(theme.mutedFG, "", false, false)
+	input.Cursor.Style = theme.lineStyle(theme.detailFG, theme.titleMetaBG, false, false)
+	return input
+}
+
+func boardStyledHelp(model help.Model, theme boardTheme, width int, showAll bool) help.Model {
+	model.Width = width
+	model.ShowAll = showAll
+	model.Styles.ShortKey = theme.lineStyle(theme.keyFG, "", true, false)
+	model.Styles.ShortDesc = theme.lineStyle(theme.helpFG, "", false, false)
+	model.Styles.ShortSeparator = theme.lineStyle(theme.mutedFG, "", false, false)
+	model.Styles.FullKey = theme.lineStyle(theme.keyFG, "", true, false)
+	model.Styles.FullDesc = theme.lineStyle(theme.helpFG, "", false, false)
+	model.Styles.FullSeparator = theme.lineStyle(theme.mutedFG, "", false, false)
+	model.Styles.Ellipsis = theme.lineStyle(theme.mutedFG, "", false, false)
+	return model
+}
+
+func boardStyledSpinner(model spinner.Model, theme boardTheme) spinner.Model {
+	model.Style = theme.lineStyle(theme.keyFG, "", true, false)
+	return model
+}
+
+func boardSyncViewportState(model boardTUIModel) boardTUIModel {
+	width := boardCurrentPanelInnerWidth(model)
+	height := boardCurrentPanelBodyHeight(model)
+
+	model.detailViewport.Width = width
+	model.detailViewport.Height = height
+	model.continuityViewport.Width = width
+	model.continuityViewport.Height = height
+
+	model.detailViewport = boardSyncViewportOffset(model, model.detailViewport, boardPanelModeDetail)
+	model.continuityViewport = boardSyncViewportOffset(model, model.continuityViewport, boardPanelModeContinuity)
+	return model
+}
+
+func boardSyncViewportOffset(model boardTUIModel, view viewport.Model, mode boardPanelMode) viewport.Model {
+	view.SetYOffset(boardPanelScrollForMode(model, mode))
+	return view
+}
+
+func boardPanelScrollForMode(model boardTUIModel, mode boardPanelMode) int {
+	if model.panelScroll == nil {
+		return 0
+	}
+	return model.panelScroll[boardPanelScrollKey(model.selectedIssue, mode)]
+}
+
+func boardViewportModelForContent(model boardTUIModel, mode boardPanelMode, content []string, width, height int) viewport.Model {
+	var view viewport.Model
+	switch mode {
+	case boardPanelModeContinuity:
+		view = model.continuityViewport
+	default:
+		view = model.detailViewport
+	}
+	view.Width = width
+	view.Height = height
+	view.SetContent(strings.Join(content, "\n"))
+	view.SetYOffset(boardPanelScrollForMode(model, mode))
+	return view
+}
+
+func boardViewportRangeLabel(view viewport.Model) string {
+	total := view.TotalLineCount()
+	visible := view.VisibleLineCount()
+	if total == 0 || total <= visible {
+		return ""
+	}
+	start := view.YOffset + 1
+	end := minInt(view.YOffset+visible, total)
+	return strconv.Itoa(start) + "-" + strconv.Itoa(end) + "/" + strconv.Itoa(total)
+}
+
+func boardHelpView(model boardTUIModel, theme boardTheme, width int, full bool) string {
+	helpModel := boardStyledHelp(model.help, theme, width, full)
+	return helpModel.View(boardKeys)
+}
+
+func boardSearchInputView(model boardTUIModel, theme boardTheme, width int) string {
+	input := boardStyledSearchInput(model.searchInput, theme, width)
+	return input.View()
+}
+
+func boardSpinnerView(model boardTUIModel, theme boardTheme) string {
+	return boardStyledSpinner(model.spinner, theme).View()
+}
+
+func boardLipGlossWidth(value string) int {
+	return lipgloss.Width(value)
+}

--- a/internal/cli/board_tui_input.go
+++ b/internal/cli/board_tui_input.go
@@ -4,16 +4,50 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
 func boardKeyInputFromKeyMsg(msg tea.KeyMsg) (boardKeyInput, bool) {
-	for _, binding := range boardKeyBindings {
-		for _, keyType := range binding.keyTypes {
-			if msg.Type == keyType {
-				return binding.input, true
-			}
-		}
+	switch {
+	case key.Matches(msg, boardKeys.Up):
+		return boardKeyInput{action: boardActionUp}, true
+	case key.Matches(msg, boardKeys.Down):
+		return boardKeyInput{action: boardActionDown}, true
+	case key.Matches(msg, boardKeys.PrevLane):
+		return boardKeyInput{action: boardActionPrevLane}, true
+	case key.Matches(msg, boardKeys.NextLane):
+		return boardKeyInput{action: boardActionNextLane}, true
+	case key.Matches(msg, boardKeys.ToggleDetail):
+		return boardKeyInput{action: boardActionToggleDetail}, true
+	case key.Matches(msg, boardKeys.Search):
+		return boardKeyInput{action: boardActionSearchOpen}, true
+	case key.Matches(msg, boardKeys.ToggleHistory):
+		return boardKeyInput{action: boardActionToggleHistory}, true
+	case key.Matches(msg, boardKeys.ToggleHelp):
+		return boardKeyInput{action: boardActionToggleHelp}, true
+	case key.Matches(msg, boardKeys.ToggleContinuity):
+		return boardKeyInput{action: boardActionToggleContinuity}, true
+	case key.Matches(msg, boardKeys.Parent):
+		return boardKeyInput{action: boardActionParent}, true
+	case key.Matches(msg, boardKeys.Child):
+		return boardKeyInput{action: boardActionChild}, true
+	case key.Matches(msg, boardKeys.Collapse):
+		return boardKeyInput{action: boardActionCollapse}, true
+	case key.Matches(msg, boardKeys.Expand):
+		return boardKeyInput{action: boardActionExpand}, true
+	case key.Matches(msg, boardKeys.Top):
+		return boardKeyInput{action: boardActionTop}, true
+	case key.Matches(msg, boardKeys.Bottom):
+		return boardKeyInput{action: boardActionBottom}, true
+	case key.Matches(msg, boardKeys.PanelPageUp):
+		return boardKeyInput{action: boardActionPanelPageUp}, true
+	case key.Matches(msg, boardKeys.PanelPageDown):
+		return boardKeyInput{action: boardActionPanelPageDown}, true
+	case key.Matches(msg, boardKeys.Backspace):
+		return boardKeyInput{backspace: true}, true
+	case key.Matches(msg, boardKeys.Quit):
+		return boardKeyInput{action: boardActionQuit}, true
 	}
 
 	if msg.Type != tea.KeyRunes || len(msg.Runes) == 0 {
@@ -21,14 +55,6 @@ func boardKeyInputFromKeyMsg(msg tea.KeyMsg) (boardKeyInput, bool) {
 	}
 
 	text := string(msg.Runes)
-	for _, binding := range boardKeyBindings {
-		for _, keyRune := range binding.runes {
-			if text == keyRune {
-				return binding.input, true
-			}
-		}
-	}
-
 	if isPrintableInput(text) {
 		return boardKeyInput{text: text}, true
 	}

--- a/internal/cli/board_tui_keymap.go
+++ b/internal/cli/board_tui_keymap.go
@@ -1,166 +1,88 @@
 package cli
 
-import tea "github.com/charmbracelet/bubbletea"
+import "github.com/charmbracelet/bubbles/key"
 
-type boardKeyBinding struct {
-	label       string
-	description string
-	input       boardKeyInput
-	keyTypes    []tea.KeyType
-	runes       []string
-	help        bool
+type boardKeyMap struct {
+	Up               key.Binding
+	Down             key.Binding
+	PrevLane         key.Binding
+	NextLane         key.Binding
+	ToggleDetail     key.Binding
+	Search           key.Binding
+	ToggleHistory    key.Binding
+	ToggleHelp       key.Binding
+	ToggleContinuity key.Binding
+	Parent           key.Binding
+	Child            key.Binding
+	Collapse         key.Binding
+	Expand           key.Binding
+	Top              key.Binding
+	Bottom           key.Binding
+	PanelPageUp      key.Binding
+	PanelPageDown    key.Binding
+	Backspace        key.Binding
+	Quit             key.Binding
 }
 
-var boardKeyBindings = []boardKeyBinding{
-	{
-		label:       "up / k",
-		description: "move selection",
-		input:       boardKeyInput{action: boardActionUp},
-		keyTypes:    []tea.KeyType{tea.KeyUp},
-		runes:       []string{"k"},
-		help:        true,
-	},
-	{
-		label:       "down / j",
-		description: "move selection",
-		input:       boardKeyInput{action: boardActionDown},
-		keyTypes:    []tea.KeyType{tea.KeyDown},
-		runes:       []string{"j"},
-		help:        true,
-	},
-	{
-		label:       "left / h",
-		description: "switch lanes",
-		input:       boardKeyInput{action: boardActionPrevLane},
-		keyTypes:    []tea.KeyType{tea.KeyLeft},
-		runes:       []string{"h"},
-		help:        true,
-	},
-	{
-		label:       "right / l",
-		description: "switch lanes",
-		input:       boardKeyInput{action: boardActionNextLane},
-		keyTypes:    []tea.KeyType{tea.KeyRight},
-		runes:       []string{"l"},
-		help:        true,
-	},
-	{
-		label:       "enter",
-		description: "toggle issue detail / confirm search",
-		input:       boardKeyInput{action: boardActionToggleDetail},
-		keyTypes:    []tea.KeyType{tea.KeyEnter, tea.KeySpace},
-		help:        true,
-	},
-	{
-		label:       "/",
-		description: "search visible issue ids",
-		input:       boardKeyInput{action: boardActionSearchOpen},
-		runes:       []string{"/"},
-		help:        true,
-	},
-	{
-		label:       "f",
-		description: "toggle actionable/all work",
-		input:       boardKeyInput{action: boardActionToggleHistory},
-		runes:       []string{"f"},
-		help:        true,
-	},
-	{
-		label:       "?",
-		description: "toggle help",
-		input:       boardKeyInput{action: boardActionToggleHelp},
-		runes:       []string{"?"},
-		help:        true,
-	},
-	{
-		label:       "c",
-		description: "toggle detail / continuity",
-		input:       boardKeyInput{action: boardActionToggleContinuity},
-		runes:       []string{"c"},
-		help:        true,
-	},
-	{
-		label:       "[ / ]",
-		description: "jump parent / child",
-		input:       boardKeyInput{action: boardActionParent},
-		runes:       []string{"["},
-		help:        true,
-	},
-	{
-		label:       "[ / ]",
-		description: "jump parent / child",
-		input:       boardKeyInput{action: boardActionChild},
-		runes:       []string{"]"},
-	},
-	{
-		label:       "{ / }",
-		description: "collapse / expand subtree",
-		input:       boardKeyInput{action: boardActionCollapse},
-		runes:       []string{"{"},
-		help:        true,
-	},
-	{
-		label:       "{ / }",
-		description: "collapse / expand subtree",
-		input:       boardKeyInput{action: boardActionExpand},
-		runes:       []string{"}"},
-	},
-	{
-		label:       "g / G",
-		description: "jump top / bottom",
-		input:       boardKeyInput{action: boardActionTop},
-		runes:       []string{"g"},
-		help:        true,
-	},
-	{
-		label:       "g / G",
-		description: "jump top / bottom",
-		input:       boardKeyInput{action: boardActionBottom},
-		runes:       []string{"G"},
-	},
-	{
-		label:       "ctrl+u / pgup",
-		description: "scroll inspector up",
-		input:       boardKeyInput{action: boardActionPanelPageUp},
-		keyTypes:    []tea.KeyType{tea.KeyCtrlU, tea.KeyPgUp},
-		help:        true,
-	},
-	{
-		label:       "ctrl+d / pgdn",
-		description: "scroll inspector down",
-		input:       boardKeyInput{action: boardActionPanelPageDown},
-		keyTypes:    []tea.KeyType{tea.KeyCtrlD, tea.KeyPgDown},
-		help:        true,
-	},
-	{
-		label:       "backspace",
-		description: "edit search",
-		input:       boardKeyInput{backspace: true},
-		keyTypes:    []tea.KeyType{tea.KeyBackspace, tea.KeyCtrlH},
-	},
-	{
-		label:       "q / esc",
-		description: "quit / cancel search",
-		input:       boardKeyInput{action: boardActionQuit},
-		keyTypes:    []tea.KeyType{tea.KeyEsc, tea.KeyCtrlC},
-		runes:       []string{"q"},
-		help:        true,
-	},
+var boardKeys = boardKeyMap{
+	Up:               key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("up/k", "move selection")),
+	Down:             key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("down/j", "move selection")),
+	PrevLane:         key.NewBinding(key.WithKeys("left", "h"), key.WithHelp("left/h", "switch lanes")),
+	NextLane:         key.NewBinding(key.WithKeys("right", "l"), key.WithHelp("right/l", "switch lanes")),
+	ToggleDetail:     key.NewBinding(key.WithKeys("enter", " "), key.WithHelp("enter", "detail / confirm search")),
+	Search:           key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "search issue ids")),
+	ToggleHistory:    key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "toggle actionable/all work")),
+	ToggleHelp:       key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "toggle help")),
+	ToggleContinuity: key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "toggle detail / continuity")),
+	Parent:           key.NewBinding(key.WithKeys("["), key.WithHelp("[", "jump parent")),
+	Child:            key.NewBinding(key.WithKeys("]"), key.WithHelp("]", "jump child")),
+	Collapse:         key.NewBinding(key.WithKeys("{"), key.WithHelp("{", "collapse subtree")),
+	Expand:           key.NewBinding(key.WithKeys("}"), key.WithHelp("}", "expand subtree")),
+	Top:              key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "jump top")),
+	Bottom:           key.NewBinding(key.WithKeys("G"), key.WithHelp("G", "jump bottom")),
+	PanelPageUp:      key.NewBinding(key.WithKeys("ctrl+u", "pgup"), key.WithHelp("ctrl+u/pgup", "scroll inspector up")),
+	PanelPageDown:    key.NewBinding(key.WithKeys("ctrl+d", "pgdown"), key.WithHelp("ctrl+d/pgdn", "scroll inspector down")),
+	Backspace:        key.NewBinding(key.WithKeys("backspace", "ctrl+h")),
+	Quit:             key.NewBinding(key.WithKeys("esc", "ctrl+c", "q"), key.WithHelp("q/esc", "quit / cancel search")),
 }
 
-func boardHelpBindings() []boardKeyBinding {
-	entries := make([]boardKeyBinding, 0, len(boardKeyBindings))
-	seen := make(map[string]struct{}, len(boardKeyBindings))
-	for _, binding := range boardKeyBindings {
-		if !binding.help {
-			continue
-		}
-		key := binding.label + "\x00" + binding.description
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		entries = append(entries, binding)
+func (boardKeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{
+		boardKeys.Up,
+		boardKeys.PrevLane,
+		boardKeys.ToggleDetail,
+		boardKeys.Search,
+		boardKeys.ToggleHistory,
+		boardKeys.ToggleHelp,
+		boardKeys.Quit,
 	}
-	return entries
+}
+
+func (boardKeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{
+			boardKeys.Up,
+			boardKeys.Down,
+			boardKeys.PrevLane,
+			boardKeys.NextLane,
+			boardKeys.Top,
+			boardKeys.Bottom,
+		},
+		{
+			boardKeys.ToggleDetail,
+			boardKeys.ToggleContinuity,
+			boardKeys.PanelPageUp,
+			boardKeys.PanelPageDown,
+		},
+		{
+			boardKeys.Search,
+			boardKeys.ToggleHistory,
+			boardKeys.Parent,
+			boardKeys.Child,
+			boardKeys.Collapse,
+			boardKeys.Expand,
+			boardKeys.ToggleHelp,
+			boardKeys.Quit,
+		},
+	}
 }

--- a/internal/cli/board_tui_model.go
+++ b/internal/cli/board_tui_model.go
@@ -4,6 +4,10 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
 	"github.com/willbastian/memori/internal/store"
 )
 
@@ -80,21 +84,30 @@ type boardTUIModel struct {
 	activeAuditRequestID    int
 	nextAuditRequestID      int
 	panelScroll             map[string]int
-	spinnerFrame            int
+	searchInput             textinput.Model
+	help                    help.Model
+	spinner                 spinner.Model
+	detailViewport          viewport.Model
+	continuityViewport      viewport.Model
 	toast                   boardToast
 	nextToastID             int
 }
 
 func newBoardTUIModel(snapshot boardSnapshot, width, height int) boardTUIModel {
 	model := boardTUIModel{
-		snapshot:    snapshot,
-		width:       maxInt(width, 24),
-		height:      maxInt(height, 10),
-		lane:        boardLaneNext,
-		detailOpen:  false,
-		panelMode:   boardPanelModeDetail,
-		expanded:    make(map[string]bool),
-		panelScroll: make(map[string]int),
+		snapshot:           snapshot,
+		width:              maxInt(width, 24),
+		height:             maxInt(height, 10),
+		lane:               boardLaneNext,
+		detailOpen:         false,
+		panelMode:          boardPanelModeDetail,
+		expanded:           make(map[string]bool),
+		panelScroll:        make(map[string]int),
+		searchInput:        newBoardSearchInput(),
+		help:               newBoardHelp(),
+		spinner:            newBoardSpinner(),
+		detailViewport:     newBoardViewport(),
+		continuityViewport: newBoardViewport(),
 	}
 	return boardNormalizeModel(model)
 }
@@ -151,7 +164,8 @@ func boardNormalizeModel(model boardTUIModel) boardTUIModel {
 	}
 
 	model = boardClampSelection(model)
-	return boardClampPanelScroll(model)
+	model.searchQuery = model.searchInput.Value()
+	return boardClampPanelScroll(boardSyncViewportState(model))
 }
 
 func boardClampSearchSelection(model boardTUIModel) boardTUIModel {

--- a/internal/cli/board_tui_panels.go
+++ b/internal/cli/board_tui_panels.go
@@ -190,10 +190,11 @@ func boardLaneRowStyle(theme boardTheme, lane boardLane, row boardIssueRow) (fg,
 	return fg, "", bold, false
 }
 
-func boardHelpPanel(theme boardTheme, width, height int) []string {
+func boardHelpPanel(model boardTUIModel, theme boardTheme, width, height int) []string {
 	lines := []string{boardPanelHeader(theme, "Keyboard", "Quick reference", width)}
-	for _, binding := range boardHelpBindings() {
-		lines = append(lines, boardHelpLine(theme, binding.label, binding.description, width))
+	helpText := boardHelpView(model, theme, width, width >= 56)
+	for _, line := range strings.Split(helpText, "\n") {
+		lines = append(lines, padRight(line, width))
 	}
 	for len(lines) < height {
 		lines = append(lines, padRight("", width))
@@ -211,11 +212,7 @@ func boardSearchPanel(model boardTUIModel, theme boardTheme, width, height int) 
 		subtitle += fmt.Sprintf(" · %d/%d", minInt(model.searchIndex+1, len(results)), len(results))
 	}
 	lines = append(lines, boardPanelHeader(theme, "Search", subtitle, width))
-	prompt := "/"
-	if model.searchQuery != "" {
-		prompt += model.searchQuery
-	}
-	lines = append(lines, theme.paintLine(theme.detailFG, theme.panelAltBG, true, padRight(" "+prompt+" ", width)))
+	lines = append(lines, theme.paintLine(theme.detailFG, theme.panelAltBG, true, padRight(" "+boardSearchInputView(model, theme, maxInt(width-2, 1))+" ", width)))
 	hint := " short hash, full id, or mem- prefix; press f to include history "
 	lines = append(lines, theme.paintLine(theme.mutedFG, "", false, padRight(truncateBoardLine(hint, width), width)))
 	if len(results) == 0 {
@@ -261,12 +258,6 @@ func boardSearchPanel(model boardTUIModel, theme boardTheme, width, height int) 
 		lines = append(lines, padRight("", width))
 	}
 	return lines[:height]
-}
-
-func boardHelpLine(theme boardTheme, key, desc string, width int) string {
-	keyText := theme.paintLine(theme.keyFG, "", true, " ["+padRight(key, 14)+"] ")
-	descText := theme.paintLine(theme.helpFG, "", false, desc)
-	return padVisual(keyText+descText, width)
 }
 
 func boardSearchHighlightedID(issueID, query string, theme boardTheme) string {

--- a/internal/cli/board_tui_side_panel.go
+++ b/internal/cli/board_tui_side_panel.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"fmt"
 	"strings"
+
+	"github.com/charmbracelet/bubbles/spinner"
 )
 
 type boardPanelContent struct {
@@ -34,8 +36,10 @@ func boardSidePanelContent(model boardTUIModel, theme boardTheme, width int) boa
 func boardRenderViewportPanel(model boardTUIModel, content boardPanelContent, theme boardTheme, width, height int) []string {
 	lines := make([]string, 0, height)
 	visibleBody := maxInt(height-1, 0)
-	body, _, rangeLabel := boardViewportWindow(content.body, visibleBody, boardCurrentPanelScroll(model))
-	subtitle := boardPanelSubtitle(content.subtitle, boardInspectorStatusTokens(model), rangeLabel)
+	view := boardViewportModelForContent(model, model.panelMode, content.body, width, visibleBody)
+	rangeLabel := boardViewportRangeLabel(view)
+	body := strings.Split(view.View(), "\n")
+	subtitle := boardPanelSubtitle(content.subtitle, boardInspectorStatusTokens(model, theme), rangeLabel)
 	lines = append(lines, boardPanelHeader(theme, content.title, subtitle, width))
 	lines = append(lines, body...)
 	for len(lines) < height {
@@ -86,23 +90,23 @@ func boardPanelSubtitle(base string, tokens []string, rangeLabel string) string 
 	return strings.Join(parts, " · ")
 }
 
-func boardInspectorStatusTokens(model boardTUIModel) []string {
+func boardInspectorStatusTokens(model boardTUIModel, theme boardTheme) []string {
 	tokens := make([]string, 0, 2)
-	if token := boardLoadToken("snapshot", model.snapshotLoad, model.spinnerFrame); token != "" {
+	if token := boardLoadToken("snapshot", model.snapshotLoad, boardStyledSpinner(model.spinner, theme)); token != "" {
 		tokens = append(tokens, token)
 	}
-	if token := boardLoadToken("audit", model.auditLoad, model.spinnerFrame); token != "" {
+	if token := boardLoadToken("audit", model.auditLoad, boardStyledSpinner(model.spinner, theme)); token != "" {
 		tokens = append(tokens, token)
 	}
 	return tokens
 }
 
-func boardLoadToken(label string, state boardAsyncLoadState, frame int) string {
+func boardLoadToken(label string, state boardAsyncLoadState, spin spinner.Model) string {
 	switch {
 	case state.loading && state.stale:
-		return label + " stale " + boardSpinnerGlyph(frame)
+		return label + " stale " + spin.View()
 	case state.loading:
-		return label + " " + boardSpinnerGlyph(frame)
+		return label + " " + spin.View()
 	case strings.TrimSpace(state.err) != "" && state.stale:
 		return label + " stale"
 	case strings.TrimSpace(state.err) != "":

--- a/internal/cli/board_tui_status.go
+++ b/internal/cli/board_tui_status.go
@@ -95,26 +95,12 @@ func boardStartAuditLoad(model boardTUIModel) (boardTUIModel, int) {
 	return model, model.activeAuditRequestID
 }
 
-func boardSpinnerGlyph(frame int) string {
-	frames := []string{"-", "\\", "|", "/"}
-	if len(frames) == 0 {
-		return "-"
-	}
-	if frame < 0 {
-		frame = 0
-	}
-	return frames[frame%len(frames)]
-}
-
 func boardPanelScrollKey(issueID string, mode boardPanelMode) string {
 	return boardPanelModeTitle(mode) + ":" + strings.TrimSpace(issueID)
 }
 
 func boardCurrentPanelScroll(model boardTUIModel) int {
-	if model.panelScroll == nil {
-		return 0
-	}
-	return model.panelScroll[boardPanelScrollKey(model.selectedIssue, model.panelMode)]
+	return boardPanelScrollForMode(model, model.panelMode)
 }
 
 func boardSetCurrentPanelScroll(model boardTUIModel, offset int) boardTUIModel {
@@ -129,6 +115,12 @@ func boardSetCurrentPanelScroll(model boardTUIModel, offset int) boardTUIModel {
 		return model
 	}
 	model.panelScroll[key] = offset
+	switch model.panelMode {
+	case boardPanelModeContinuity:
+		model.continuityViewport.SetYOffset(offset)
+	default:
+		model.detailViewport.SetYOffset(offset)
+	}
 	return model
 }
 
@@ -149,12 +141,21 @@ func boardMaxPanelScroll(model boardTUIModel) int {
 		return 0
 	}
 	content := boardSidePanelContent(model, defaultBoardTheme(false), boardCurrentPanelInnerWidth(model))
-	visible := boardCurrentPanelBodyHeight(model)
-	return maxInt(len(content.body)-visible, 0)
+	view := boardViewportModelForContent(model, model.panelMode, content.body, boardCurrentPanelInnerWidth(model), boardCurrentPanelBodyHeight(model))
+	return maxInt(view.TotalLineCount()-view.VisibleLineCount(), 0)
 }
 
 func boardAdjustPanelScroll(model boardTUIModel, delta int) boardTUIModel {
-	return boardSetCurrentPanelScroll(model, boardCurrentPanelScroll(model)+delta)
+	content := boardSidePanelContent(model, defaultBoardTheme(false), boardCurrentPanelInnerWidth(model))
+	view := boardViewportModelForContent(model, model.panelMode, content.body, boardCurrentPanelInnerWidth(model), boardCurrentPanelBodyHeight(model))
+	switch {
+	case delta < 0:
+		view.ScrollUp(-delta)
+	case delta > 0:
+		view.ScrollDown(delta)
+	}
+	model = boardSetCurrentPanelScroll(model, view.YOffset)
+	return boardSyncViewportState(model)
 }
 
 func boardCurrentPanelInnerWidth(model boardTUIModel) int {

--- a/internal/cli/board_tui_text.go
+++ b/internal/cli/board_tui_text.go
@@ -2,7 +2,8 @@ package cli
 
 import (
 	"strings"
-	"unicode/utf8"
+
+	"github.com/charmbracelet/x/ansi"
 )
 
 func wrapText(value string, width int) []string {
@@ -40,28 +41,8 @@ func padVisual(value string, width int) string {
 	return value + strings.Repeat(" ", width-visualWidth(value))
 }
 
-func stripANSI(value string) string {
-	var out strings.Builder
-	inEscape := false
-	for i := 0; i < len(value); i++ {
-		ch := value[i]
-		if inEscape {
-			if ch == 'm' {
-				inEscape = false
-			}
-			continue
-		}
-		if ch == 0x1b {
-			inEscape = true
-			continue
-		}
-		out.WriteByte(ch)
-	}
-	return out.String()
-}
-
 func visualWidth(value string) int {
-	return utf8.RuneCountInString(stripANSI(value))
+	return ansi.StringWidth(value)
 }
 
 func trimVisual(value string, width int) string {
@@ -71,73 +52,5 @@ func trimVisual(value string, width int) string {
 	if visualWidth(value) <= width {
 		return value
 	}
-	raw := stripANSI(value)
-	var out strings.Builder
-	count := 0
-	for _, r := range raw {
-		if count >= width {
-			break
-		}
-		out.WriteRune(r)
-		count++
-	}
-	return out.String()
-}
-
-func replaceSegment(line string, start int, segment string) string {
-	linePrefix, raw, lineSuffix := splitANSIWrapper(line)
-	if start >= visualWidth(raw) {
-		return line
-	}
-	prefix := trimVisual(raw, start)
-	suffixStart := start + visualWidth(segment)
-	if suffixStart > visualWidth(raw) {
-		suffixStart = visualWidth(raw)
-	}
-	suffix := sliceVisual(raw, suffixStart, visualWidth(raw)-suffixStart)
-	return wrapWithANSI(linePrefix, prefix, lineSuffix) + segment + wrapWithANSI(linePrefix, suffix, lineSuffix)
-}
-
-func sliceVisual(value string, start, width int) string {
-	if width <= 0 {
-		return ""
-	}
-	raw := stripANSI(value)
-	if start < 0 {
-		start = 0
-	}
-	var out strings.Builder
-	index := 0
-	count := 0
-	for _, r := range raw {
-		if index < start {
-			index++
-			continue
-		}
-		if count >= width {
-			break
-		}
-		out.WriteRune(r)
-		index++
-		count++
-	}
-	return out.String()
-}
-
-func splitANSIWrapper(value string) (prefix, raw, suffix string) {
-	if !strings.HasPrefix(value, "\x1b[") || !strings.HasSuffix(value, "\x1b[0m") {
-		return "", value, ""
-	}
-	idx := strings.IndexByte(value, 'm')
-	if idx < 0 {
-		return "", value, ""
-	}
-	return value[:idx+1], value[idx+1 : len(value)-4], "\x1b[0m"
-}
-
-func wrapWithANSI(prefix, raw, suffix string) string {
-	if raw == "" {
-		return ""
-	}
-	return prefix + raw + suffix
+	return ansi.Truncate(value, width, "")
 }

--- a/internal/cli/board_tui_update.go
+++ b/internal/cli/board_tui_update.go
@@ -1,6 +1,11 @@
 package cli
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+)
 
 func boardReduce(model boardTUIModel, action boardAction) boardTUIModel {
 	switch action {
@@ -77,15 +82,71 @@ func boardReduce(model boardTUIModel, action boardAction) boardTUIModel {
 
 func boardHandleInput(model boardTUIModel, input boardKeyInput) (boardTUIModel, bool) {
 	if model.searchOpen {
-		return boardHandleSearchInput(model, input)
+		switch {
+		case input.action == boardActionQuit:
+			model.searchOpen = false
+			model.searchQuery = ""
+			model.searchInput.Blur()
+			model.searchInput.Reset()
+			model.searchIndex = 0
+			if model.searchOrigin != "" {
+				model = boardFocusIssuePreferred(model, model.searchOrigin, boardLanePreference(model.searchLane, model.navigationLanes()))
+			}
+			return model, false
+		case input.action == boardActionToggleDetail:
+			results := boardSearchResults(model)
+			if len(results) == 0 {
+				return model, false
+			}
+			model.searchOpen = false
+			model.searchQuery = ""
+			model.searchInput.Blur()
+			model.searchInput.Reset()
+			selected := results[minInt(model.searchIndex, len(results)-1)]
+			model = boardFocusIssuePreferred(model, selected.row.Issue.ID, boardLanePreference(selected.lane, model.navigationLanes()))
+			model = boardSetToast(model, boardToastToneSuccess, "Jumped to "+selected.row.Issue.ID+" in "+strings.ToLower(boardLaneTitle(selected.lane)))
+			return model, false
+		case input.action == boardActionToggleHistory:
+			model.showHistory = !model.showHistory
+			return boardNormalizeModel(model), false
+		case input.backspace:
+			value := model.searchInput.Value()
+			if len(value) > 0 {
+				model.searchInput.SetValue(value[:len(value)-1])
+			}
+			model.searchQuery = model.searchInput.Value()
+			model.searchIndex = 0
+			return boardNormalizeModel(model), false
+		case input.text != "":
+			model.searchInput.SetValue(model.searchInput.Value() + input.text)
+			model.searchQuery = model.searchInput.Value()
+			model.searchIndex = 0
+			return boardNormalizeModel(model), false
+		case input.action == boardActionDown:
+			model.searchIndex++
+			return boardNormalizeModel(model), false
+		case input.action == boardActionUp:
+			model.searchIndex--
+			return boardNormalizeModel(model), false
+		case input.action == boardActionTop:
+			model.searchIndex = 0
+			return boardNormalizeModel(model), false
+		case input.action == boardActionBottom:
+			model.searchIndex = maxInt(len(boardSearchResults(model))-1, 0)
+			return boardNormalizeModel(model), false
+		default:
+			return model, false
+		}
 	}
 
 	if input.action == boardActionSearchOpen {
 		model.searchOpen = true
+		model.searchInput.Reset()
 		model.searchQuery = ""
 		model.searchIndex = 0
 		model.searchOrigin = model.selectedIssue
 		model.searchLane = model.lane
+		_ = model.searchInput.Focus()
 		return boardNormalizeModel(model), false
 	}
 
@@ -93,54 +154,51 @@ func boardHandleInput(model boardTUIModel, input boardKeyInput) (boardTUIModel, 
 	return model, input.action == boardActionQuit
 }
 
-func boardHandleSearchInput(model boardTUIModel, input boardKeyInput) (boardTUIModel, bool) {
+func boardHandleSearchInput(model boardTUIModel, msg tea.KeyMsg) (boardTUIModel, bool) {
 	switch {
-	case input.action == boardActionQuit:
+	case key.Matches(msg, boardKeys.Quit):
 		model.searchOpen = false
 		model.searchQuery = ""
 		model.searchIndex = 0
+		model.searchInput.Blur()
 		if model.searchOrigin != "" {
 			model = boardFocusIssuePreferred(model, model.searchOrigin, boardLanePreference(model.searchLane, model.navigationLanes()))
 		}
 		return model, false
-	case input.action == boardActionToggleDetail:
+	case key.Matches(msg, boardKeys.ToggleDetail):
 		results := boardSearchResults(model)
 		if len(results) == 0 {
 			return model, false
 		}
 		model.searchOpen = false
 		model.searchQuery = ""
+		model.searchInput.Blur()
 		selected := results[minInt(model.searchIndex, len(results)-1)]
 		model = boardFocusIssuePreferred(model, selected.row.Issue.ID, boardLanePreference(selected.lane, model.navigationLanes()))
 		model = boardSetToast(model, boardToastToneSuccess, "Jumped to "+selected.row.Issue.ID+" in "+strings.ToLower(boardLaneTitle(selected.lane)))
 		return model, false
-	case input.action == boardActionToggleHistory:
+	case key.Matches(msg, boardKeys.ToggleHistory):
 		model.showHistory = !model.showHistory
 		model = boardNormalizeModel(model)
 		return model, false
-	case input.backspace:
-		if len(model.searchQuery) > 0 {
-			model.searchQuery = model.searchQuery[:len(model.searchQuery)-1]
-		}
-		model.searchIndex = 0
-		return boardNormalizeModel(model), false
-	case input.text != "":
-		model.searchQuery += input.text
-		model.searchIndex = 0
-		return boardNormalizeModel(model), false
-	case input.action == boardActionDown:
+	case key.Matches(msg, boardKeys.Down):
 		model.searchIndex++
 		return boardNormalizeModel(model), false
-	case input.action == boardActionUp:
+	case key.Matches(msg, boardKeys.Up):
 		model.searchIndex--
 		return boardNormalizeModel(model), false
-	case input.action == boardActionTop:
+	case key.Matches(msg, boardKeys.Top):
 		model.searchIndex = 0
 		return boardNormalizeModel(model), false
-	case input.action == boardActionBottom:
+	case key.Matches(msg, boardKeys.Bottom):
 		model.searchIndex = maxInt(len(boardSearchResults(model))-1, 0)
 		return boardNormalizeModel(model), false
 	default:
-		return model, false
+		var cmd tea.Cmd
+		model.searchInput, cmd = model.searchInput.Update(msg)
+		_ = cmd
+		model.searchQuery = model.searchInput.Value()
+		model.searchIndex = 0
+		return boardNormalizeModel(model), false
 	}
 }

--- a/internal/cli/board_tui_view.go
+++ b/internal/cli/board_tui_view.go
@@ -119,10 +119,10 @@ func renderBoardTUI(model boardTUIModel, colors bool) string {
 		if width >= 100 {
 			panelWidth := minInt(maxInt(width-18, 52), 76)
 			panelHeight := minInt(maxInt(bodyHeight-4, 10), 16)
-			help := boardHelpPanel(theme, maxInt(panelWidth-2, 1), maxInt(panelHeight-2, 1))
+			help := boardHelpPanel(model, theme, maxInt(panelWidth-2, 1), maxInt(panelHeight-2, 1))
 			lines = append(lines, boardOverlayPanel(theme, help, width, bodyHeight, panelWidth, panelHeight)...)
 		} else {
-			help := boardHelpPanel(theme, maxInt(width-2, 1), maxInt(bodyHeight-2, 1))
+			help := boardHelpPanel(model, theme, maxInt(width-2, 1), maxInt(bodyHeight-2, 1))
 			lines = append(lines, boardFramePanel(theme, help, width, bodyHeight)...)
 		}
 	} else if model.searchOpen {
@@ -495,26 +495,7 @@ func (theme boardTheme) paintLine(fg, bg string, bold bool, value string) string
 }
 
 func (theme boardTheme) paintLineStyled(fg, bg string, bold, dim bool, value string) string {
-	if !theme.colors {
-		return value
-	}
-	codes := make([]string, 0, 4)
-	if bold {
-		codes = append(codes, "1")
-	}
-	if dim {
-		codes = append(codes, "2")
-	}
-	if fg != "" {
-		codes = append(codes, "38;2;"+fg)
-	}
-	if bg != "" {
-		codes = append(codes, "48;2;"+bg)
-	}
-	if len(codes) == 0 {
-		return value
-	}
-	return "\x1b[" + strings.Join(codes, ";") + "m" + value + "\x1b[0m"
+	return theme.lineStyle(fg, bg, bold, dim).Render(value)
 }
 
 func (theme boardTheme) lineStyle(fg, bg string, bold, dim bool) lipgloss.Style {

--- a/internal/cli/cli_board_tui_helpers_test.go
+++ b/internal/cli/cli_board_tui_helpers_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/willbastian/memori/internal/store"
 )
 
@@ -191,16 +193,12 @@ func TestBoardThemePaintLineHonorsColorMode(t *testing.T) {
 
 	colorTheme := boardTheme{colors: true}
 	got := colorTheme.paintLine("1;2;3", "4;5;6", true, "hello")
-	if !strings.HasPrefix(got, "\x1b[1;38;2;1;2;3;48;2;4;5;6m") {
-		t.Fatalf("expected ANSI prefix, got %q", got)
+	if !strings.Contains(got, "hello") {
+		t.Fatalf("expected lipgloss-rendered content to preserve text, got %q", got)
 	}
-	if !strings.HasSuffix(got, "hello\x1b[0m") {
-		t.Fatalf("expected ANSI suffix, got %q", got)
-	}
-
 	dimmed := colorTheme.paintLineStyled("1;2;3", "", false, true, "hello")
-	if !strings.HasPrefix(dimmed, "\x1b[2;38;2;1;2;3m") {
-		t.Fatalf("expected dim ANSI prefix, got %q", dimmed)
+	if !strings.Contains(dimmed, "hello") {
+		t.Fatalf("expected dimmed lipgloss render to preserve text, got %q", dimmed)
 	}
 }
 
@@ -236,25 +234,13 @@ func TestTrimVisualPreservesANSIWhenValueAlreadyFits(t *testing.T) {
 	}
 }
 
-func TestReplaceSegmentPreservesOuterANSIWrapper(t *testing.T) {
+func TestBoardSearchHighlightedIDUsesLipGlossHighlighting(t *testing.T) {
 	t.Parallel()
 
 	theme := boardTheme{colors: true}
-	line := theme.paintLine("1;2;3", "4;5;6", true, padRight(" HEADER ", 20))
-	segment := theme.paintLine("7;8;9", "10;11;12", true, " META ")
-
-	got := replaceSegment(line, 10, segment)
-	if visualWidth(got) != 20 {
-		t.Fatalf("expected replaced line to preserve rendered width 20, got %d (%q)", visualWidth(got), got)
-	}
-	if !strings.HasPrefix(got, "\x1b[1;38;2;1;2;3;48;2;4;5;6m") {
-		t.Fatalf("expected replaced line to retain outer style prefix, got %q", got)
-	}
-	if strings.Count(got, "\x1b[0m") < 3 {
-		t.Fatalf("expected replaced line to restyle prefix, segment, and suffix, got %q", got)
-	}
-	if !strings.Contains(stripANSI(got), "META") {
-		t.Fatalf("expected replaced line to include inserted meta text, got %q", stripANSI(got))
+	got := boardSearchHighlightedID("mem-abcd123", "abcd", theme)
+	if stripped := ansi.Strip(got); stripped != "mem-abcd123" {
+		t.Fatalf("expected highlighted id to preserve id text, got %q", stripped)
 	}
 }
 
@@ -359,13 +345,6 @@ func TestBoardStatusAndViewportHelpersCoverAsyncBranches(t *testing.T) {
 		t.Fatalf("expected mismatched toast clear to preserve toast")
 	}
 
-	if got := boardSpinnerGlyph(-1); got != "-" {
-		t.Fatalf("expected negative spinner frame to clamp to '-', got %q", got)
-	}
-	if got := boardSpinnerGlyph(2); got != "|" {
-		t.Fatalf("expected spinner frame 2 to be '|', got %q", got)
-	}
-
 	if got := boardCurrentPanelScroll(boardTUIModel{}); got != 0 {
 		t.Fatalf("expected nil panel scroll map to read as zero, got %d", got)
 	}
@@ -412,19 +391,20 @@ func TestBoardStatusAndViewportHelpersCoverAsyncBranches(t *testing.T) {
 	loadModel := boardTUIModel{
 		snapshotLoad: boardAsyncLoadState{loading: true, stale: true},
 		auditLoad:    boardAsyncLoadState{err: "boom"},
-		spinnerFrame: 1,
+		spinner:      newBoardSpinner(),
 	}
-	if got := boardInspectorStatusTokens(loadModel); !reflect.DeepEqual(got, []string{`snapshot stale \`, "audit failed"}) {
+	theme := defaultBoardTheme(false)
+	if got := boardInspectorStatusTokens(loadModel, theme); !reflect.DeepEqual(got, []string{"snapshot stale |", "audit failed"}) {
 		t.Fatalf("unexpected inspector status tokens %#v", got)
 	}
 
-	if got := boardLoadToken("snapshot", boardAsyncLoadState{loading: true}, 3); got != "snapshot /" {
+	if got := boardLoadToken("snapshot", boardAsyncLoadState{loading: true}, spinner.New(spinner.WithSpinner(spinner.Line))); got != "snapshot |" {
 		t.Fatalf("unexpected active load token %q", got)
 	}
-	if got := boardLoadToken("snapshot", boardAsyncLoadState{stale: true}, 0); got != "snapshot stale" {
+	if got := boardLoadToken("snapshot", boardAsyncLoadState{stale: true}, spinner.New(spinner.WithSpinner(spinner.Line))); got != "snapshot stale" {
 		t.Fatalf("unexpected stale load token %q", got)
 	}
-	if got := boardLoadToken("snapshot", boardAsyncLoadState{}, 0); got != "" {
+	if got := boardLoadToken("snapshot", boardAsyncLoadState{}, spinner.New(spinner.WithSpinner(spinner.Line))); got != "" {
 		t.Fatalf("expected empty load token, got %q", got)
 	}
 
@@ -839,8 +819,8 @@ func TestBoardThemeAndColorHelpersCoverRemainingBranches(t *testing.T) {
 		t.Fatalf("expected line style render to contain content, got %q", rendered)
 	}
 
-	if got := stripANSI(colorTheme.rule(5)); got != "·····" {
-		t.Fatalf("unexpected rule rendering %q", stripANSI(colorTheme.rule(5)))
+	if got := ansi.Strip(colorTheme.rule(5)); got != "·····" {
+		t.Fatalf("unexpected rule rendering %q", ansi.Strip(colorTheme.rule(5)))
 	}
 }
 
@@ -852,11 +832,11 @@ func TestBoardToastLineAndColorModeBranches(t *testing.T) {
 	}
 
 	model.toast = boardToast{message: "saved", tone: boardToastToneSuccess}
-	if got := stripANSI(boardToastLine(model, theme, 30)); !strings.Contains(got, "saved") {
+	if got := ansi.Strip(boardToastLine(model, theme, 30)); !strings.Contains(got, "saved") {
 		t.Fatalf("expected success toast line to contain message, got %q", got)
 	}
 	model.toast = boardToast{message: "warn", tone: boardToastToneWarn}
-	if got := stripANSI(boardToastLine(model, theme, 30)); !strings.Contains(got, "warn") {
+	if got := ansi.Strip(boardToastLine(model, theme, 30)); !strings.Contains(got, "warn") {
 		t.Fatalf("expected warn toast line to contain message, got %q", got)
 	}
 

--- a/internal/cli/cli_board_tui_helpers_test.go
+++ b/internal/cli/cli_board_tui_helpers_test.go
@@ -824,6 +824,21 @@ func TestBoardThemeAndColorHelpersCoverRemainingBranches(t *testing.T) {
 	}
 }
 
+func TestBoardKeyMapShortHelpIncludesPrimaryBindings(t *testing.T) {
+	t.Parallel()
+
+	short := boardKeys.ShortHelp()
+	if len(short) != 7 {
+		t.Fatalf("expected 7 short help bindings, got %d", len(short))
+	}
+	if short[0].Help().Desc != "move selection" {
+		t.Fatalf("expected first short help binding to describe movement, got %+v", short[0].Help())
+	}
+	if short[len(short)-1].Help().Desc != "quit / cancel search" {
+		t.Fatalf("expected last short help binding to describe quit/cancel, got %+v", short[len(short)-1].Help())
+	}
+}
+
 func TestBoardToastLineAndColorModeBranches(t *testing.T) {
 	theme := defaultBoardTheme(false)
 	model := boardTUIModel{}

--- a/internal/cli/cli_board_tui_input_semantics_test.go
+++ b/internal/cli/cli_board_tui_input_semantics_test.go
@@ -1,6 +1,10 @@
 package cli
 
-import "testing"
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
 
 func TestBoardTUISearchNavigationClampsWithinResults(t *testing.T) {
 	t.Parallel()
@@ -133,5 +137,86 @@ func TestBoardTUIHandleQuitReturnsQuitFlag(t *testing.T) {
 	}
 	if next.selectedIssue != model.selectedIssue || next.lane != model.lane {
 		t.Fatalf("expected quit action to preserve current selection, got %+v", next)
+	}
+}
+
+func TestBoardHandleSearchInputUsesTeaKeyMsgsForEditCancelAndConfirm(t *testing.T) {
+	t.Parallel()
+
+	model := newBoardTUIModel(boardSnapshot{
+		Ready: []boardIssueRow{
+			{Issue: boardTestIssue("mem-a111111", "Task", "Todo", "Ready one")},
+		},
+		Blocked: []boardIssueRow{
+			{Issue: boardTestIssue("mem-b222222", "Bug", "Blocked", "Blocked one")},
+		},
+	}, 120, 28)
+	model.lane = boardLaneReady
+	model = boardNormalizeModel(model)
+	model, _ = boardHandleInput(model, boardKeyInput{action: boardActionSearchOpen})
+
+	updated, quit := boardHandleSearchInput(model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("b22")})
+	if quit {
+		t.Fatal("did not expect tea search input update to quit")
+	}
+	if updated.searchQuery != "b22" || updated.searchIndex != 0 {
+		t.Fatalf("expected tea search text entry to update query and reset index, got %+v", updated)
+	}
+
+	updated, quit = boardHandleSearchInput(updated, tea.KeyMsg{Type: tea.KeyDown})
+	if quit || updated.searchIndex != 0 {
+		t.Fatalf("expected down to clamp to the only result, got %+v quit=%v", updated, quit)
+	}
+
+	updated, quit = boardHandleSearchInput(updated, tea.KeyMsg{Type: tea.KeyEnter})
+	if quit {
+		t.Fatal("did not expect enter confirm to quit")
+	}
+	if updated.searchOpen || updated.selectedIssue != "mem-b222222" || updated.lane != boardLaneBlocked {
+		t.Fatalf("expected enter confirm to jump to blocked issue, got %+v", updated)
+	}
+	if updated.toast.message == "" {
+		t.Fatalf("expected successful search confirm to set a toast, got %+v", updated.toast)
+	}
+
+	model, _ = boardHandleInput(model, boardKeyInput{action: boardActionSearchOpen})
+	model.searchInput.SetValue("b22")
+	model.searchQuery = model.searchInput.Value()
+	model = boardNormalizeModel(model)
+	updated, quit = boardHandleSearchInput(model, tea.KeyMsg{Type: tea.KeyEsc})
+	if quit {
+		t.Fatal("did not expect esc cancel to quit")
+	}
+	if updated.searchOpen || updated.selectedIssue != model.searchOrigin || updated.lane != model.searchLane {
+		t.Fatalf("expected esc to restore origin selection and close search, got %+v", updated)
+	}
+}
+
+func TestBoardHandleSearchInputSupportsHistoryToggleAndBoundsNavigation(t *testing.T) {
+	t.Parallel()
+
+	model := newBoardTUIModel(boardSnapshot{
+		Ready: []boardIssueRow{{Issue: boardTestIssue("mem-a111111", "Task", "Todo", "Ready one")}},
+		Done:  []boardIssueRow{{Issue: boardTestIssue("mem-c333333", "Task", "Done", "Done one")}},
+	}, 120, 28)
+	model = boardNormalizeModel(model)
+	model, _ = boardHandleInput(model, boardKeyInput{action: boardActionSearchOpen})
+
+	updated, quit := boardHandleSearchInput(model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	if quit || !updated.showHistory {
+		t.Fatalf("expected f to toggle history inside search, got %+v quit=%v", updated, quit)
+	}
+
+	updated, quit = boardHandleSearchInput(updated, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("mem")})
+	if quit {
+		t.Fatal("did not expect text entry to quit")
+	}
+	updated, quit = boardHandleSearchInput(updated, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}})
+	if quit || updated.searchIndex != len(boardSearchResults(updated))-1 {
+		t.Fatalf("expected G to jump to the last result, got index=%d len=%d quit=%v", updated.searchIndex, len(boardSearchResults(updated)), quit)
+	}
+	updated, quit = boardHandleSearchInput(updated, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
+	if quit || updated.searchIndex != 0 {
+		t.Fatalf("expected g to jump back to the first result, got %+v quit=%v", updated, quit)
 	}
 }

--- a/internal/cli/cli_board_tui_loop_test.go
+++ b/internal/cli/cli_board_tui_loop_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/willbastian/memori/internal/store"
 )
@@ -249,8 +250,8 @@ func TestBoardLoadCommandsReturnExpectedMessages(t *testing.T) {
 		t.Fatalf("unexpected audit msg %#v", auditMsg)
 	}
 
-	if _, ok := boardScheduleSpinner()().(boardSpinnerTickMsg); !ok {
-		t.Fatalf("expected spinner cmd to emit boardSpinnerTickMsg")
+	if _, ok := newBoardSpinner().Tick().(spinner.TickMsg); !ok {
+		t.Fatalf("expected spinner tick cmd to emit spinner.TickMsg")
 	}
 	if msg := boardExpireToastCmd(17)(); msg.(boardToastExpiredMsg).id != 17 {
 		t.Fatalf("expected toast expiry id 17, got %#v", msg)
@@ -363,10 +364,11 @@ func TestBoardTeaModelUpdateHandlesSuccessSpinnerAndToastLifecycle(t *testing.T)
 	}
 
 	updated.state.snapshotLoad = boardBeginAsyncLoad(updated.state.snapshotLoad)
-	updatedModel, cmd = updated.Update(boardSpinnerTickMsg{})
+	before := updated.state.spinner.View()
+	updatedModel, cmd = updated.Update(updated.state.spinner.Tick())
 	updated = updatedModel.(boardTeaModel)
-	if cmd == nil || updated.state.spinnerFrame != 1 {
-		t.Fatalf("expected spinner tick to advance frame, got frame=%d cmd=%v", updated.state.spinnerFrame, cmd != nil)
+	if cmd == nil || updated.state.spinner.View() == before {
+		t.Fatalf("expected spinner tick to advance the bubbles spinner, got before=%q after=%q cmd=%v", before, updated.state.spinner.View(), cmd != nil)
 	}
 
 	updated.state = boardSetToast(updated.state, boardToastToneInfo, "toast")
@@ -410,10 +412,11 @@ func TestBoardTeaModelUpdateHandlesIgnoredAuditAndCanceledErrors(t *testing.T) {
 	}
 
 	updated.state.snapshotLoad = boardAsyncLoadState{}
-	updatedModel, cmd = updated.Update(boardSpinnerTickMsg{})
+	before := updated.state.spinner.View()
+	updatedModel, cmd = updated.Update(updated.state.spinner.Tick())
 	updated = updatedModel.(boardTeaModel)
-	if cmd != nil || updated.state.spinnerFrame != 0 {
-		t.Fatalf("expected idle spinner tick to do nothing, got frame=%d cmd=%v", updated.state.spinnerFrame, cmd != nil)
+	if cmd != nil || updated.state.spinner.View() != before {
+		t.Fatalf("expected idle spinner tick to do nothing, got before=%q after=%q cmd=%v", before, updated.state.spinner.View(), cmd != nil)
 	}
 }
 

--- a/internal/cli/cli_board_tui_render_test.go
+++ b/internal/cli/cli_board_tui_render_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/willbastian/memori/internal/store"
 )
 
@@ -259,8 +260,8 @@ func TestRenderBoardTUINarrowShowsSinglePaneAndHelp(t *testing.T) {
 	for _, want := range []string{
 		"KEYBOARD",
 		"move selection",
-		"jump parent / child",
-		"quit",
+		"toggle detail / continuity",
+		"scroll inspector down",
 	} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("expected narrow help render to contain %q, got:\n%s", want, rendered)
@@ -294,7 +295,7 @@ func TestBoardListPanelPadsColoredRowsToPanelWidth(t *testing.T) {
 	lines := boardListPanel(model, theme, 32, 4)
 	for _, idx := range []int{1, 2} {
 		if got := visualWidth(lines[idx]); got != 32 {
-			t.Fatalf("expected rendered row %d to be padded to width 32, got %d (%q)", idx, got, stripANSI(lines[idx]))
+			t.Fatalf("expected rendered row %d to be padded to width 32, got %d (%q)", idx, got, ansi.Strip(lines[idx]))
 		}
 	}
 }
@@ -328,14 +329,13 @@ func TestBoardSearchPanelPadsColoredRowsToPanelWidth(t *testing.T) {
 	if quit {
 		t.Fatalf("did not expect search open to quit")
 	}
-	model, quit = boardHandleInput(model, boardKeyInput{text: "b22"})
-	if quit {
-		t.Fatalf("did not expect text entry to quit")
-	}
+	model.searchInput.SetValue("b22")
+	model.searchQuery = model.searchInput.Value()
+	model = boardNormalizeModel(model)
 
 	lines := boardSearchPanel(model, theme, 32, 4)
 	if got := visualWidth(lines[2]); got != 32 {
-		t.Fatalf("expected rendered search row to be padded to width 32, got %d (%q)", got, stripANSI(lines[2]))
+		t.Fatalf("expected rendered search row to be padded to width 32, got %d (%q)", got, ansi.Strip(lines[2]))
 	}
 }
 
@@ -376,7 +376,7 @@ func TestBoardDetailPanelPadsColoredSectionLinesToPanelWidth(t *testing.T) {
 	lines := boardDetailPanel(model, theme, 40, 12)
 	for _, idx := range []int{5, 7, 9} {
 		if got := visualWidth(lines[idx]); got != 40 {
-			t.Fatalf("expected detail line %d to be padded to width 40, got %d (%q)", idx, got, stripANSI(lines[idx]))
+			t.Fatalf("expected detail line %d to be padded to width 40, got %d (%q)", idx, got, ansi.Strip(lines[idx]))
 		}
 	}
 }
@@ -395,11 +395,8 @@ func TestBoardFramePanelPreservesStyledRowContent(t *testing.T) {
 	line := theme.paintLine(theme.selectedFG, theme.selectedBG, true, padRight(" selected row ", 16))
 	panel := boardFramePanel(theme, []string{line}, 18, 3)
 
-	if !strings.Contains(panel[1], "\x1b[1;38;2;7;8;9;48;2;10;11;12m") {
-		t.Fatalf("expected framed panel to preserve row styling, got %q", panel[1])
-	}
-	if !strings.Contains(stripANSI(panel[1]), "selected row") {
-		t.Fatalf("expected framed panel to preserve row content, got %q", stripANSI(panel[1]))
+	if !strings.Contains(ansi.Strip(panel[1]), "selected row") {
+		t.Fatalf("expected framed panel to preserve row content, got %q", ansi.Strip(panel[1]))
 	}
 }
 
@@ -607,10 +604,9 @@ func TestRenderBoardTUIShowsSearchPanel(t *testing.T) {
 	if quit {
 		t.Fatalf("did not expect search open to quit")
 	}
-	model, quit = boardHandleInput(model, boardKeyInput{text: "b22"})
-	if quit {
-		t.Fatalf("did not expect text entry to quit")
-	}
+	model.searchInput.SetValue("b22")
+	model.searchQuery = model.searchInput.Value()
+	model = boardNormalizeModel(model)
 
 	rendered := renderBoardTUI(model, false)
 	for _, want := range []string{
@@ -645,10 +641,9 @@ func TestRenderBoardTUINarrowShowsSearchPanel(t *testing.T) {
 	if quit {
 		t.Fatalf("did not expect search open to quit")
 	}
-	model, quit = boardHandleInput(model, boardKeyInput{text: "b22"})
-	if quit {
-		t.Fatalf("did not expect text entry to quit")
-	}
+	model.searchInput.SetValue("b22")
+	model.searchQuery = model.searchInput.Value()
+	model = boardNormalizeModel(model)
 
 	rendered := renderBoardTUI(model, false)
 	for _, want := range []string{


### PR DESCRIPTION
## Summary
- replace the remaining board ANSI/string-painting renderer seams with Lip Gloss-backed composition
- adopt Bubbles textinput, viewport, spinner, and help/key metadata for the interactive board surfaces
- expand board regression coverage and document the Bubble Tea, Bubbles, and Lip Gloss-first architecture in the README

## Testing
- env GOCACHE=/tmp/memori-gocache go test ./...

## Tracking
- mem-9e09b80
- mem-530e750
- mem-3e56ad1